### PR TITLE
Add Sphinx/ReadTheDocs-powered documentation

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -1,0 +1,55 @@
+Contributing
+============
+
+We welcome your contributions to Kagi and strive to make it as easy as possible
+to participate.
+
+Initial Set-up
+--------------
+
+.. highlight:: none
+
+The first step is to install Poetry_::
+
+   curl -sSL https://raw.githubusercontent.com/sdispater/poetry/master/get-poetry.py | python
+
+Next, install Pre-commit_. Here we will install Pipx_ and use it to install Pre-commit_::
+
+   python3 -m pip install --user pipx
+   python3 -m pipx ensurepath
+   pipx install pre-commit
+
+Tell Pre-commit_ where to store its Git hooks, such as ``~/.local/share/git/templates``.
+This only needs to be done once per workstation, so if you have already run these
+commands for another project, you can skip this step::
+
+   mkdir -p ~/.local/share/git/templates
+   git config --global init.templateDir ~/.local/share/git/templates
+   pre-commit init-templatedir ~/.local/share/git/templates
+
+Go to the `Kagi repository`_ on GitHub and tap the **Fork** button at top-right.
+Then clone the source for your fork and add the upstream project as a Git remote::
+
+   git clone https://github.com/YOUR_USERNAME/kagi.git
+   cd kagi
+   git remote add upstream https://github.com/justinmayer/kagi.git
+
+**(optional)** Poetry will automatically create a virtual environment for you but
+will alternatively use an already-activated environment if you prefer to create
+and activate your virtual environments manually::
+
+   python3 -m venv ~/virtualenvs/kagi
+   source ~/virtualenvs/kagi/bin/activate
+
+Install Kagi and its dependencies via Poetry_::
+
+   poetry install
+
+Your local environment should now be ready to go!
+
+.. Links
+
+.. _`Kagi repository`: https://github.com/justinmayer/kagi
+.. _Pipx: https://pipxproject.github.io/pipx/installation/
+.. _Poetry: https://poetry.eustace.io/docs/#installation
+.. _Pre-commit: https://pre-commit.com/

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,0 +1,46 @@
+import os
+
+on_rtd = os.environ.get("READTHEDOCS", None) == "True"
+
+
+# -- Project information -----------------------------------------------------
+
+project = "Kagi"
+copyright = "2019 – present, Justin Mayer & Rémy Hubscher"
+author = "Justin Mayer & Rémy Hubscher"
+
+
+# -- General configuration ---------------------------------------------------
+
+extensions = ["sphinx.ext.autosectionlabel", "sphinx.ext.extlinks"]
+templates_path = ["_templates"]
+exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
+
+
+# -- Options for HTML output -------------------------------------------------
+
+html_theme = "default"
+if not on_rtd:
+    try:
+        import sphinx_rtd_theme
+
+        html_theme = "sphinx_rtd_theme"
+        html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
+    except ImportError:
+        pass
+
+html_static_path = ["_static"]
+
+# If false, no module index is generated.
+html_use_modindex = False
+
+# If false, no index is generated.
+html_use_index = False
+
+# If true, links to the reST sources are added to the pages.
+html_show_sourcelink = False
+
+
+# -- Extension Configuration -------------------------------------------------
+
+extlinks = {"issue": ("https://github.com/justinmayer/kagi/issues/%s", "issue ")}

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -1,0 +1,1 @@
+.. include:: ../CONTRIBUTING.rst

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,0 +1,16 @@
+Kagi
+====
+
+Kagi provides support for WebAuthn_ / FIDO2 security keys and TOTP tokens in Django_.
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Contents:
+
+   Home <self>
+   contributing
+
+.. Links
+
+.. _Django: https://www.djangoproject.com/
+.. _WebAuthn: https://en.wikipedia.org/wiki/WebAuthn

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,8 @@ pytest-django = "^3.5"
 pytest-emoji = "^0.2.0"
 pytest-pythonpath = "^0.7.3"
 pytest-sugar = "^0.9.2"
+sphinx = "^2.2"
+sphinx_rtd_theme = "^0.4.3"
 Werkzeug = "^0.15.5"
 
 [build-system]


### PR DESCRIPTION
Following up on #13, this adds an initial `CONTRIBUTING` file as well as base structure and configuration for Sphinx/ReadTheDocs-powered documentation.

This isn't intended to _close_ #13 since we still need to add more documentation regarding how to actually use Kagi, but this should be a good start upon which to build.