### PR TITLE
Show warning in browsers that don't support WebAuthn

### DIFF
--- a/docs/customization.rst
+++ b/docs/customization.rst
@@ -1,0 +1,18 @@
+Customization
+#############
+
+Handling Unsupported Browsers
+=============================
+
+The provided ``webauthn.js`` file detects whether browsers support WebAuthn, and
+if not, displays or hides selected element IDs as appropriate. There are matching
+element IDs in the bundled templates, which can be useful as a guide for how to
+handle this in customized templates.
+
+Elements with ID ``webauthn-feature`` will be set to ``style="display: none"``.
+This is for hiding functional elements that require WebAuthn support, since using
+those elements in an unsupported browser would only result in errors.
+
+Elements with ID ``webauthn-undefined-error`` will be set to ``style="display: block"``.
+This is useful for displaying a warning in unsupported browsers, along with a link
+to a list of compatible browsers.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -9,6 +9,7 @@ Kagi provides support for WebAuthn_ / FIDO2 security keys and TOTP tokens in Dja
 
    Home <self>
    community
+   customization
    troubleshooting
 
 .. Links

--- a/kagi/static/kagi/webauthn.js
+++ b/kagi/static/kagi/webauthn.js
@@ -316,4 +316,14 @@ document.addEventListener("DOMContentLoaded", e => {
   if (loginElement) {
       loginElement.addEventListener('click', didClickLogin);
   }
+  // If browser doesn't support WebAuthn, hide related elements and show warning
+  if (typeof(PublicKeyCredential) == "undefined") {
+    var webAuthnFeature = document.getElementById("webauthn-feature");
+    if (webAuthnFeature) {
+      webAuthnFeature.style.display = "none";
+    }
+    var webAuthnUndefinedError = document.getElementById("webauthn-undefined-error");
+    if (webAuthnUndefinedError) {
+      webAuthnUndefinedError.style.display = "block"; }
+    }
 });

--- a/kagi/templates/kagi/base.html
+++ b/kagi/templates/kagi/base.html
@@ -16,12 +16,8 @@
 
 <div id="webauthn-undefined-error" style="display: none">
     {% blocktrans %}
-    You must be using a compatible browser to use a WebAuthn security key.
-    The following browsers are known to be compatible:
+    This browser is not among the <a href="https://caniuse.com/webauthn" target="_blank">
+    list of browsers that support WebAuthn security keys.</a>
     {% endblocktrans %}
-    <ul>
-      <li>{% trans 'Firefox 67 and higher' %}
-      <li>{% trans 'Chrome 67 and higher' %}
-    </ul>
 </div>
 {% endblock %}

--- a/kagi/templates/kagi/base.html
+++ b/kagi/templates/kagi/base.html
@@ -14,16 +14,14 @@
 </script>
 {{ block.super }}
 
-{% comment %}
-TODO: Handle browser not supporting navigator.credentials API.
-{% endcomment %}
-<div id="kagi-not-defined-error" style="display: none">
+<div id="webauthn-undefined-error" style="display: none">
     {% blocktrans %}
     You must be using a compatible browser to use a WebAuthn security key.
-    The following browsers are known to be compatible
+    The following browsers are known to be compatible:
     {% endblocktrans %}
     <ul>
-      <li>{% trans 'Chrome 41 and higher' %}
+      <li>{% trans 'Firefox 67 and higher' %}
+      <li>{% trans 'Chrome 67 and higher' %}
     </ul>
 </div>
 {% endblock %}

--- a/kagi/templates/kagi/key_list.html
+++ b/kagi/templates/kagi/key_list.html
@@ -1,5 +1,6 @@
 {% extends "kagi/base.html" %}
 {% load i18n %}
+{% load static %}
 
 {% block content %}
 {{ block.super }}
@@ -30,5 +31,9 @@
     {% endfor %}
   </tbody>
 </table>
-<a href="{% url 'kagi:add-webauthn-key' %}">{% trans 'Add another key' %}</a>
+<div id="webauthn-feature">
+  <a href="{% url 'kagi:add-webauthn-key' %}">{% trans 'Add another key' %}</a>
+</div>
+
+<script src="{% static 'kagi/webauthn.js' %}"></script>
 {% endblock %}

--- a/kagi/templates/kagi/verify_second_factor.html
+++ b/kagi/templates/kagi/verify_second_factor.html
@@ -14,9 +14,11 @@
 <form id="login-form">
     {% csrf_token %}
     <div id="webauthn-error" style="color: red"></div>
-    <button id="login" type="button">
-        {% trans "Tap here to log in with your WebAuthn key." %}
-    </button>
+    <div id="webauthn-feature">
+      <button id="login" type="button">
+          {% trans "Tap here to log in with your WebAuthn key." %}
+      </button>
+    </div>
 </form>
 {% endif %}
 


### PR DESCRIPTION
WebAuthn is built upon the PublicKeyCredential part of the Credentials
Management API. We now check for PublicKeyCredential, and if undefined,
we show a warning as well as hide certain buttons and links when related
pages are loaded in browsers that lack WebAuthn support.

Fixes #35