### PR TITLE
Use get_username() instead of hardcoded user.username

### DIFF
--- a/kagi/views/api.py
+++ b/kagi/views/api.py
@@ -213,7 +213,7 @@ def webauthn_verify_assertion(request):
 
     return JsonResponse(
         {
-            "success": "Successfully authenticated as {}".format(user.username),
+            "success": "Successfully authenticated as {}".format(username),
             "redirect_to": redirect_to,
         }
     )


### PR DESCRIPTION
If the user model does not contain a `username` field (as is the case when using email addresses as usernames), referencing `user.username` results in an error. Since the `username` variable is already properly set to `get_username()` earlier in the function, it seems appropriate to use that variable for the authentication success message as well.
