### PR TITLE
Update Documented Poetry Installation Process

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -9,7 +9,7 @@ Quick Set-up
 
 First, install Poetry_::
 
-    curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/install-poetry.py | python -
+    curl -sSL https://install.python-poetry.org/ | python -
 
 Go to the `Kagi repository`_ on GitHub and tap the **Fork** button at top-right.
 Then clone the source for your fork and add the upstream project as a Git remote::
@@ -33,7 +33,7 @@ Detailed Set-up
 
 The first step is to install Poetry_::
 
-    curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/install-poetry.py | python -
+    curl -sSL https://install.python-poetry.org/ | python -
 
 Next, install Pre-commit_. Here we will install Pipx_ and use it to install Pre-commit_::
 

--- a/README.rst
+++ b/README.rst
@@ -53,7 +53,7 @@ following steps (creating and activating a virtual environment first is optional
 
 First, install Poetry_::
 
-    curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/install-poetry.py | python -
+    curl -sSL https://install.python-poetry.org/ | python -
 
 Clone the Kagi source code and switch to its directory::
 


### PR DESCRIPTION
When installing Poetry as documented in the README and CONTRIBUTING guides, the following message is displayed:

```
$ curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/install-poetry.py | python -
The canonical source for Poetry's installation script is now https://install.python-poetry.org. Please update your usage to reflect this.
```

This PR updates the README and CONTRIBUTING files to use the new canonical source for Poetry's installation script.
