### PR TITLE
Updated pre-commit configuration and sync with pyproject.toml.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,40 +19,43 @@ repos:
       - id: trailing-whitespace
 
   - repo: https://github.com/psf/black
-    rev: 22.8.0
+    rev: 22.12.0
     hooks:
       - id: black
 
   - repo: https://github.com/PyCQA/flake8
-    rev: 4.0.1
+    rev: 5.0.4
     hooks:
       - id: flake8
-        args: [--max-line-length=88]
+        additional_dependencies: [Flake8-pyproject]
 
   - repo: https://github.com/PyCQA/isort
-    rev: 5.10.1
+    rev: 5.11.4
     hooks:
       - id: isort
 
-  - repo: https://github.com/Lucas-C/pre-commit-hooks-bandit
-    rev: v1.0.6
+  - repo: https://github.com/PyCQA/bandit
+    rev: 1.7.4
     hooks:
-      - id: python-bandit-vulnerability-check
-        args: [-lll, --recursive, --exclude, "**/node_modules/**", .]
+      - id: bandit
+        args: ["-lll", "-vr", "kagi", "testproj"]
 
   - repo: https://github.com/Lucas-C/pre-commit-hooks-safety
     rev: v1.3.0
     hooks:
       - id: python-safety-dependencies-check
+        # 51457: https://github.com/pytest-dev/py/issues/287
+        args: ["--disable-telemetry", "--ignore=51457"]
+        files: pyproject.toml
 
   - repo: https://github.com/asottile/pyupgrade
-    rev: v2.38.0
+    rev: v3.3.1
     hooks:
       - id: pyupgrade
         args: [--py37-plus]
 
   - repo: https://github.com/hakancelikdev/unimport
-    rev: 0.11.3
+    rev: 0.12.3
     hooks:
       - id: unimport
         args: [--remove, --include-star-import]

--- a/kagi/management/commands/addbackupcode.py
+++ b/kagi/management/commands/addbackupcode.py
@@ -1,6 +1,3 @@
-from django.contrib.auth import get_user_model
-from django.core.management.base import BaseCommand, CommandError
-
 """
 This is inspired by addstatictoken in django-otp, which is licensed as follows:
 
@@ -28,6 +25,8 @@ This is inspired by addstatictoken in django-otp, which is licensed as follows:
     OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
     OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 """
+from django.contrib.auth import get_user_model
+from django.core.management.base import BaseCommand, CommandError
 
 
 class Command(BaseCommand):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,12 +34,11 @@ webauthn = "^0.4"
 Flake8-pyproject = "^1.1.0.post0"
 
 [tool.poetry.dev-dependencies]
-black = "^22.8"
+black = "^22.12"
 flake8 = "^5.0"
-flake8-black = "^0.3"
 furo = "2022.04.07"
 invoke = "^1.3"
-isort = "^5.2"
+isort = "^5.11"
 livereload = "^2.6"
 psutil = {version = "^5.7", optional = true}
 pyOpenSSL = "^22.0"
@@ -58,12 +57,8 @@ git-email = "botpub@autopub.rocks"
 append-github-contributor = true
 
 [tool.isort]
-# Maintain compatibility with Black
+profile = "black"
 combine_as_imports = true
-force_grid_wrap = 0
-include_trailing_comma = true
-line_length = 88
-multi_line_output = 3
 
 # Sort imports within their section independent of the import type
 force_sort_within_sections = true


### PR DESCRIPTION
The changes include:

 * Updated black, isort, pyupgrade, unimport hooks
 * Updated flake8 hook and let it read config from pyproject.toml
 * Changed to official bandit hook and limit scan to kagi/testproj (otherwise .venv etc will get scanned as well)
 * Updated safety hook, disabled telemetry and disabled a false positive
 * Fixed a flake8 error (addbackupcode.py)
 * Updated pyproject.toml to use isort's black profile