### PR TITLE
Updated pre-commit versions and matched them in pyproject.toml.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@
 # See https://pre-commit.com/hooks.html for info on hooks
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.3.0
+    rev: v4.4.0
     hooks:
       - id: check-added-large-files
       - id: check-ast
@@ -19,7 +19,7 @@ repos:
       - id: trailing-whitespace
 
   - repo: https://github.com/psf/black
-    rev: 22.12.0
+    rev: 23.3.0
     hooks:
       - id: black
 
@@ -30,18 +30,18 @@ repos:
         additional_dependencies: [Flake8-pyproject]
 
   - repo: https://github.com/PyCQA/isort
-    rev: 5.11.4
+    rev: 5.11.5
     hooks:
       - id: isort
 
   - repo: https://github.com/PyCQA/bandit
-    rev: 1.7.4
+    rev: 1.7.5
     hooks:
       - id: bandit
         args: ["-lll", "-vr", "kagi", "testproj"]
 
   - repo: https://github.com/Lucas-C/pre-commit-hooks-safety
-    rev: v1.3.0
+    rev: v1.3.1
     hooks:
       - id: python-safety-dependencies-check
         # 51457: https://github.com/pytest-dev/py/issues/287
@@ -49,13 +49,13 @@ repos:
         files: pyproject.toml
 
   - repo: https://github.com/asottile/pyupgrade
-    rev: v3.3.1
+    rev: v3.4.0
     hooks:
       - id: pyupgrade
         args: [--py37-plus]
 
   - repo: https://github.com/hakancelikdev/unimport
-    rev: 0.12.3
+    rev: 0.16.0
     hooks:
       - id: unimport
         args: [--remove, --include-star-import]

--- a/kagi/migrations/0001_initial.py
+++ b/kagi/migrations/0001_initial.py
@@ -6,7 +6,6 @@ import django.db.models.deletion
 
 
 class Migration(migrations.Migration):
-
     initial = True
 
     dependencies = [migrations.swappable_dependency(settings.AUTH_USER_MODEL)]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,11 +31,11 @@ Django = ">= 2.2"
 python = ">= 3.7, < 4.0"
 qrcode = ">= 6.1, < 8.0"
 webauthn = "^0.4"
-Flake8-pyproject = "^1.1.0.post0"
 
 [tool.poetry.dev-dependencies]
-black = "^22.12"
+black = "^23.3"
 flake8 = "^5.0"
+Flake8-pyproject = "^1.2.3"
 furo = "2022.04.07"
 invoke = "^1.3"
 isort = "^5.11"


### PR DESCRIPTION
Please note that this didn't upgrade all versions fully to still support Python3.7.