### PR TITLE
Limit kagi to (Small)AutoField for now. Refs #55.

### DIFF
--- a/kagi/apps.py
+++ b/kagi/apps.py
@@ -3,6 +3,7 @@ from django.apps import AppConfig
 
 class KagiConfig(AppConfig):
     name = "kagi"
+    default_auto_field = "django.db.models.AutoField"
 
     def monkeypatch_login_view(self):
         from .admin import monkeypatch_admin


### PR DESCRIPTION
This is a "quickfix" basically. We have to think what we want and then probably migrate to `BigAutoField`. But this prevents migrations from being generated for now.