### PR TITLE
fix: Correctly set a WebAuthN key's last used timestamp

### DIFF
--- a/kagi/views/api.py
+++ b/kagi/views/api.py
@@ -189,7 +189,7 @@ def webauthn_verify_assertion(request):
 
     # Update counter.
     key.sign_count = sign_count
-    key.last_used = now()
+    key.last_used_at = now()
     key.save()
 
     try:


### PR DESCRIPTION
Fixes #48, #56