### PR TITLE
feat: Prevent secret submission from the client when adding TOTP devices

### DIFF
--- a/kagi/constants.py
+++ b/kagi/constants.py
@@ -1,0 +1,1 @@
+SESSION_TOTP_SECRET_KEY = "kagi_totp_secret"

--- a/kagi/templates/kagi/totp_device.html
+++ b/kagi/templates/kagi/totp_device.html
@@ -21,7 +21,6 @@
 <form method="POST">
   {% csrf_token %}
   {{ form.as_p }}
-  <input type="hidden" name="base32_key" value="{{ base32_key }}">
   <button value="backup" name="type">{% trans 'Submit' %}</button>
 </form>
 

--- a/kagi/views/totp_devices.py
+++ b/kagi/views/totp_devices.py
@@ -9,7 +9,6 @@ from django.contrib.sites.shortcuts import get_current_site
 from django.http import HttpResponseRedirect
 from django.shortcuts import get_object_or_404, redirect
 from django.urls import reverse, reverse_lazy
-from django.utils.functional import cached_property
 from django.utils.http import url_has_allowed_host_and_scheme, urlencode
 from django.utils.translation import gettext as _
 from django.views.generic import FormView, ListView

--- a/kagi/views/totp_devices.py
+++ b/kagi/views/totp_devices.py
@@ -37,13 +37,13 @@ class AddTOTPDeviceView(OriginMixin, FormView):
         # This approach allows to re-enter the token if mistyped, while keeping
         # the same TOTP device setup on the TOTP generator.
         self.secret = self.gen_secret()
-        self.request.session[SESSION_TOTP_SECRET_KEY] = self.secret
+        request.session[SESSION_TOTP_SECRET_KEY] = self.secret
         return super().get(request, *args, **kwargs)
 
     def post(self, request, *args: str, **kwargs):
         # Try to get the TOTP secret from the session. If the secret doesn't
         # exist, redirect to the view again, to configure a new TOTP secret.
-        self.secret = self.request.session.get(SESSION_TOTP_SECRET_KEY, None)
+        self.secret = request.session.get(SESSION_TOTP_SECRET_KEY, None)
         if not self.secret:
             messages.error(request, _("Missing TOTP secret. Please try again."))
             return redirect(request.path)


### PR DESCRIPTION
Previously, a client could submit the secret for a TOTP device when adding it, through a hidden `base32_key` form field. With this commit, the secret is kept in a user session to remove a client's control over the secret.

Let's leave the PR open until we've issued a new version.