### PR TITLE
Replace SvgPathImage with SvgPathFillImage for accessibility

### DIFF
--- a/kagi/views/totp_devices.py
+++ b/kagi/views/totp_devices.py
@@ -15,7 +15,7 @@ from django.utils.translation import gettext as _
 from django.views.generic import FormView, ListView
 
 import qrcode
-from qrcode.image.svg import SvgPathImage
+from qrcode.image.svg import SvgPathFillImage
 
 from ..forms import TOTPForm
 from ..models import TOTPDevice
@@ -43,7 +43,7 @@ class AddTOTPDeviceView(OriginMixin, FormView):
         )
 
     def get_qrcode(self, data):
-        img = qrcode.make(data, image_factory=SvgPathImage)
+        img = qrcode.make(data, image_factory=SvgPathFillImage)
         buf = BytesIO()
         img.save(buf)
         return buf.getvalue().decode("utf-8")


### PR DESCRIPTION
Currently, the QR code image_factory is `SvgPathImage`. This produces a black QR code with a transparent background. For users using dark mode on the Django admin panel, this presents an accessibility issue, shown below:

![image](https://github.com/justinmayer/kagi/assets/45047662/a28e490e-dc7e-4433-809e-6288b23043f5)
> This demo QR code is not being reused in any production environment.

I propose changing the SvgPathImage to the SvgPathFillImage, which, according to [qrcode documentation](https://pypi.org/project/qrcode/), "work the same, but also fill the background of the SVG with white." This makes the QR code visible to folks with vision impairments working in dark mode. 